### PR TITLE
Allow Params in unprotected routes

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,6 +2,7 @@
 const _ = require('lodash');
 const request = require('request');
 const urlJoin = require('url-join');
+const urlPattern = require('url-pattern');
 
 
 function authorization(options) {
@@ -19,7 +20,7 @@ function authorization(options) {
 
   return function (req, res, next) {
     if (_.some(options.unprotected, (route) => {
-        return route === req._parsedUrl.pathname
+        return new urlPattern(route).match(req._parsedUrl.pathname);
       })) {
       return next();
     }

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
   "dependencies": {
     "lodash": "^4.6.1",
     "request": "^2.69.0",
-    "url-join": "0.0.1"
+    "url-join": "0.0.1",
+    "url-pattern": "^1.0.3"
   }
 }

--- a/test/test.js
+++ b/test/test.js
@@ -121,6 +121,56 @@ describe('Access Token validation', function () {
     });
   });
 
+  describe('When calling an unprotected URI with url-params', function () {
+    it('should call next middleware (=allow access)', function (done) {
+      bearerTokenValidation({
+        validationUri: 'http://localhost:3000/oauth/tokenvalidation',
+        tokenParam: 'token',
+        unprotected: ['/public/:id', '/public/api']
+      })({
+        headers: {},
+        url: '/public/0815',
+        _parsedUrl:  { pathname: '/public/0815' }
+      }, {
+        status: function (number) {
+          return {
+            send: function () {
+              statusCode = number;
+            }
+          }
+        }
+      }, function (err) {
+        assert.equal(err, null);
+        done();
+      });
+    });
+  });
+
+  describe('When calling an unprotected URI with query params & url-params', function () {
+    it('should call next middleware (=allow access)', function (done) {
+      bearerTokenValidation({
+        validationUri: 'http://localhost:3000/oauth/tokenvalidation',
+        tokenParam: 'token',
+        unprotected: ['/public/:id', '/public/api']
+      })({
+        headers: {},
+        url: '/public/0815?id=1',
+        _parsedUrl:  { pathname: '/public/0815' }
+      }, {
+        status: function (number) {
+          return {
+            send: function () {
+              statusCode = number;
+            }
+          }
+        }
+      }, function (err) {
+        assert.equal(err, null);
+        done();
+      });
+    });
+  });
+
   describe('When validating an invalid token', function () {
     it('should return status code 401 ', function (done) {
       bearerTokenValidation({


### PR DESCRIPTION
Allow Params in unprotected routes (like in `/item/:id`)