### PR TITLE
Allow multiple tokens

### DIFF
--- a/index.js
+++ b/index.js
@@ -26,7 +26,9 @@ function authorization(options) {
     }
 
     if (req.headers.authorization) {
-      let bearerToken = req.headers.authorization.substr(7);
+      const tokens = req.headers.authorization.split(', ');
+      const bearerTokenHeader = _.find(tokens, token => token.toLowerCase().startsWith('bearer'));
+      let bearerToken = bearerTokenHeader.substr(7);
       let tokenParam = `?${options.tokenParam}=${bearerToken}`;
       var uri = urlJoin(options.validationUri, tokenParam);
       request(uri, function (err, validationResponse) {

--- a/test/test.js
+++ b/test/test.js
@@ -193,6 +193,31 @@ describe('Access Token validation', function () {
     });
   });
 
+  describe('With multiple tokens', function () {
+    it('should select the correct and call next middleware (=allow access)', function (done) {
+      bearerTokenValidation({
+        validationUri: 'http://localhost:3000/oauth/tokenvalidation',
+        tokenParam: 'token'
+      })({
+        headers: {
+          'authorization': 'bearer token, policy policytoken'
+        },
+        url: '/protected'
+      }, {
+        status: function (number) {
+          return {
+            send: function () {
+              statusCode = number;
+            }
+          }
+        }
+      }, function (err) {
+        assert.equal(err, null);
+        done();
+      });
+    });
+  });
+
   describe('When authorization header is missing', function () {
     it('should return status code 401', function (done) {
       bearerTokenValidation({


### PR DESCRIPTION
Enables this middleware to handle more than one token in `Authorization`-Header